### PR TITLE
Use metadata instead of asset key prefix to define location in lakeFS

### DIFF
--- a/src/ames_housing/__init__.py
+++ b/src/ames_housing/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 
-from dagster import Definitions
+from dagster import Definitions, repository
 
 from ames_housing.assets.ames_housing_data import ames_housing_data
 from ames_housing.assets.ames_housing_features import ames_housing_features
@@ -16,6 +16,8 @@ from ames_housing.constants import (
     AMES_HOUSING_DATA_SET_SEPARATOR,
     AMES_HOUSING_DATA_SET_URL,
     DATA_BASE_DIR,
+    LAKEFS_BRANCH,
+    LAKEFS_REPOSITORY,
     MLFLOW_EXPERIMENT,
     MLFLOW_PASSWORD,
     MLFLOW_TRACKING_URL,
@@ -31,8 +33,12 @@ from ames_housing.resources.mlflow_session import MlflowSession
 
 # Depending on the environment, serialize assets to the local file system or to lakeFS.
 if os.environ.get("ENV") == "production":
-    csv_io_manager = CSVLakeFSIOManager()
-    pickle_io_manager = PickleLakeFSIOManager()
+    csv_io_manager = CSVLakeFSIOManager(
+        repository=LAKEFS_REPOSITORY, branch=LAKEFS_BRANCH
+    )
+    pickle_io_manager = PickleLakeFSIOManager(
+        repository=LAKEFS_REPOSITORY, branch=LAKEFS_BRANCH
+    )
 else:
     csv_io_manager = CSVFileSystemIOManager(base_dir=DATA_BASE_DIR)
     pickle_io_manager = PickleFileSystemIOManager(base_dir=MODEL_BASE_DIR)
@@ -60,6 +66,5 @@ definitions = Definitions(
         ),
         "csv_io_manager": csv_io_manager,
         "pickle_io_manager": pickle_io_manager,
-        "csv_lakefs_io_manager": CSVLakeFSIOManager(),
     },
 )

--- a/src/ames_housing/assets/ames_housing_data.py
+++ b/src/ames_housing/assets/ames_housing_data.py
@@ -4,15 +4,13 @@ import pandas as pd
 from caseconverter import snakecase
 from dagster import asset
 
-from ames_housing.constants import LAKEFS_BRANCH, LAKEFS_DATA_PATH, LAKEFS_REPOSITORY
+from ames_housing.constants import LAKEFS_DATA_PATH
 from ames_housing.resources.csv_data_set_loader import CSVDataSetLoader
 
 
 @asset(
     io_manager_key="csv_io_manager",
     metadata={
-        "repository": LAKEFS_REPOSITORY,
-        "branch": LAKEFS_BRANCH,
         "path": LAKEFS_DATA_PATH,
     },
 )

--- a/src/ames_housing/assets/ames_housing_data.py
+++ b/src/ames_housing/assets/ames_housing_data.py
@@ -4,11 +4,18 @@ import pandas as pd
 from caseconverter import snakecase
 from dagster import asset
 
+from ames_housing.constants import LAKEFS_BRANCH, LAKEFS_DATA_PATH, LAKEFS_REPOSITORY
 from ames_housing.resources.csv_data_set_loader import CSVDataSetLoader
-from ames_housing.utils import get_key_prefix
 
 
-@asset(io_manager_key="csv_io_manager", key_prefix=get_key_prefix())
+@asset(
+    io_manager_key="csv_io_manager",
+    metadata={
+        "repository": LAKEFS_REPOSITORY,
+        "branch": LAKEFS_BRANCH,
+        "path": LAKEFS_DATA_PATH,
+    },
+)
 def ames_housing_data(
     ames_housing_data_set_downloader: CSVDataSetLoader,
 ) -> pd.DataFrame:

--- a/src/ames_housing/assets/ames_housing_features.py
+++ b/src/ames_housing/assets/ames_housing_features.py
@@ -4,9 +4,7 @@ import pandas as pd
 from dagster import asset
 
 from ames_housing.constants import (
-    LAKEFS_BRANCH,
     LAKEFS_DATA_PATH,
-    LAKEFS_REPOSITORY,
     SELECTED_FEATURES,
     TARGET,
 )
@@ -15,8 +13,6 @@ from ames_housing.constants import (
 @asset(
     io_manager_key="csv_io_manager",
     metadata={
-        "repository": LAKEFS_REPOSITORY,
-        "branch": LAKEFS_BRANCH,
         "path": LAKEFS_DATA_PATH,
     },
 )

--- a/src/ames_housing/assets/ames_housing_features.py
+++ b/src/ames_housing/assets/ames_housing_features.py
@@ -3,11 +3,23 @@
 import pandas as pd
 from dagster import asset
 
-from ames_housing.constants import SELECTED_FEATURES, TARGET
-from ames_housing.utils import get_key_prefix
+from ames_housing.constants import (
+    LAKEFS_BRANCH,
+    LAKEFS_DATA_PATH,
+    LAKEFS_REPOSITORY,
+    SELECTED_FEATURES,
+    TARGET,
+)
 
 
-@asset(io_manager_key="csv_io_manager", key_prefix=get_key_prefix())
+@asset(
+    io_manager_key="csv_io_manager",
+    metadata={
+        "repository": LAKEFS_REPOSITORY,
+        "branch": LAKEFS_BRANCH,
+        "path": LAKEFS_DATA_PATH,
+    },
+)
 def ames_housing_features(ames_housing_data: pd.DataFrame):
     """Ames housing features.
 

--- a/src/ames_housing/assets/price_prediction_models.py
+++ b/src/ames_housing/assets/price_prediction_models.py
@@ -5,10 +5,14 @@ import pandas as pd
 from dagster import AssetExecutionContext, asset
 from sklearn.pipeline import Pipeline
 
-from ames_housing.constants import TARGET
+from ames_housing.constants import (
+    LAKEFS_BRANCH,
+    LAKEFS_MODEL_PATH,
+    LAKEFS_REPOSITORY,
+    TARGET,
+)
 from ames_housing.model_factory import ModelFactory
 from ames_housing.resources.mlflow_session import MlflowSession
-from ames_housing.utils import get_key_prefix
 
 
 def _fit_and_score_pipeline(
@@ -49,7 +53,11 @@ def _fit_and_score_pipeline(
     return pipeline
 
 
-@asset(io_manager_key="pickle_io_manager", key_prefix=get_key_prefix())
+@asset(io_manager_key="pickle_io_manager", metadata={
+                "repository": LAKEFS_REPOSITORY,
+                "branch": LAKEFS_BRANCH,
+                "path": LAKEFS_MODEL_PATH,
+            })
 def price_prediction_linear_regression_model(
     context: AssetExecutionContext,
     mlflow_session: MlflowSession,
@@ -66,7 +74,11 @@ def price_prediction_linear_regression_model(
     )
 
 
-@asset(io_manager_key="pickle_io_manager", key_prefix=get_key_prefix())
+@asset(io_manager_key="pickle_io_manager", metadata={
+                "repository": LAKEFS_REPOSITORY,
+                "branch": LAKEFS_BRANCH,
+                "path": LAKEFS_MODEL_PATH,
+            })
 def price_prediction_random_forest_model(
     context: AssetExecutionContext,
     mlflow_session: MlflowSession,
@@ -83,7 +95,11 @@ def price_prediction_random_forest_model(
     )
 
 
-@asset(io_manager_key="pickle_io_manager", key_prefix=get_key_prefix())
+@asset(io_manager_key="pickle_io_manager", metadata={
+                "repository": LAKEFS_REPOSITORY,
+                "branch": LAKEFS_BRANCH,
+                "path": LAKEFS_MODEL_PATH,
+            })
 def price_prediction_gradient_boosting_model(
     context: AssetExecutionContext,
     mlflow_session: MlflowSession,

--- a/src/ames_housing/assets/price_prediction_models.py
+++ b/src/ames_housing/assets/price_prediction_models.py
@@ -53,11 +53,12 @@ def _fit_and_score_pipeline(
     return pipeline
 
 
-@asset(io_manager_key="pickle_io_manager", metadata={
-                "repository": LAKEFS_REPOSITORY,
-                "branch": LAKEFS_BRANCH,
-                "path": LAKEFS_MODEL_PATH,
-            })
+@asset(
+    io_manager_key="pickle_io_manager",
+    metadata={
+        "path": LAKEFS_MODEL_PATH,
+    },
+)
 def price_prediction_linear_regression_model(
     context: AssetExecutionContext,
     mlflow_session: MlflowSession,
@@ -74,11 +75,12 @@ def price_prediction_linear_regression_model(
     )
 
 
-@asset(io_manager_key="pickle_io_manager", metadata={
-                "repository": LAKEFS_REPOSITORY,
-                "branch": LAKEFS_BRANCH,
-                "path": LAKEFS_MODEL_PATH,
-            })
+@asset(
+    io_manager_key="pickle_io_manager",
+    metadata={
+        "path": LAKEFS_MODEL_PATH,
+    },
+)
 def price_prediction_random_forest_model(
     context: AssetExecutionContext,
     mlflow_session: MlflowSession,
@@ -95,11 +97,12 @@ def price_prediction_random_forest_model(
     )
 
 
-@asset(io_manager_key="pickle_io_manager", metadata={
-                "repository": LAKEFS_REPOSITORY,
-                "branch": LAKEFS_BRANCH,
-                "path": LAKEFS_MODEL_PATH,
-            })
+@asset(
+    io_manager_key="pickle_io_manager",
+    metadata={
+        "path": LAKEFS_MODEL_PATH,
+    },
+)
 def price_prediction_gradient_boosting_model(
     context: AssetExecutionContext,
     mlflow_session: MlflowSession,

--- a/src/ames_housing/assets/train_test.py
+++ b/src/ames_housing/assets/train_test.py
@@ -7,9 +7,7 @@ from dagster import AssetOut, multi_asset
 from sklearn.model_selection import train_test_split
 
 from ames_housing.constants import (
-    LAKEFS_BRANCH,
     LAKEFS_DATA_PATH,
-    LAKEFS_REPOSITORY,
     RANDOM_STATE,
 )
 
@@ -19,16 +17,12 @@ from ames_housing.constants import (
         "train_data": AssetOut(
             io_manager_key="csv_io_manager",
             metadata={
-                "repository": LAKEFS_REPOSITORY,
-                "branch": LAKEFS_BRANCH,
                 "path": LAKEFS_DATA_PATH,
             },
         ),
         "test_data": AssetOut(
             io_manager_key="csv_io_manager",
             metadata={
-                "repository": LAKEFS_REPOSITORY,
-                "branch": LAKEFS_BRANCH,
                 "path": LAKEFS_DATA_PATH,
             },
         ),

--- a/src/ames_housing/assets/train_test.py
+++ b/src/ames_housing/assets/train_test.py
@@ -6,17 +6,31 @@ import pandas as pd
 from dagster import AssetOut, multi_asset
 from sklearn.model_selection import train_test_split
 
-from ames_housing.constants import RANDOM_STATE
-from ames_housing.utils import get_key_prefix
+from ames_housing.constants import (
+    LAKEFS_BRANCH,
+    LAKEFS_DATA_PATH,
+    LAKEFS_REPOSITORY,
+    RANDOM_STATE,
+)
 
 
 @multi_asset(
     outs={
         "train_data": AssetOut(
-            io_manager_key="csv_io_manager", key_prefix=get_key_prefix()
+            io_manager_key="csv_io_manager",
+            metadata={
+                "repository": LAKEFS_REPOSITORY,
+                "branch": LAKEFS_BRANCH,
+                "path": LAKEFS_DATA_PATH,
+            },
         ),
         "test_data": AssetOut(
-            io_manager_key="csv_io_manager", key_prefix=get_key_prefix()
+            io_manager_key="csv_io_manager",
+            metadata={
+                "repository": LAKEFS_REPOSITORY,
+                "branch": LAKEFS_BRANCH,
+                "path": LAKEFS_DATA_PATH,
+            },
         ),
     }
 )

--- a/src/ames_housing/constants.py
+++ b/src/ames_housing/constants.py
@@ -21,3 +21,5 @@ MLFLOW_EXPERIMENT = "Ames housing price prediction"
 
 LAKEFS_REPOSITORY = "ai-kickstart"
 LAKEFS_BRANCH = "main"
+LAKEFS_DATA_PATH = ["data"]
+LAKEFS_MODEL_PATH = ["models"]

--- a/src/ames_housing/io_managers/base_lakefs_io_manager.py
+++ b/src/ames_housing/io_managers/base_lakefs_io_manager.py
@@ -1,6 +1,7 @@
 """Base lakeFS IO manager."""
 
 from typing import Any, Optional, Union
+from pathlib import PosixPath
 
 from dagster import ConfigurableIOManager, InputContext, OutputContext
 from lakefs.object import LakeFSIOBase
@@ -58,9 +59,7 @@ class BaseLakeFSIOManager(ConfigurableIOManager):
         metadata = get_metadata(context)
 
         repository = metadata.get("repository")
-
-        asset_path = metadata.get("path") + context.asset_key.path
-        path = "/".join(asset_path)
+        path = PosixPath(*(metadata.get("path") + context.asset_key.path))
 
         if transaction is not None:
             branch = transaction.branch.id
@@ -136,7 +135,7 @@ class BaseLakeFSIOManager(ConfigurableIOManager):
                 context.log.debug(f"Writing file at: {self.get_path(context)}")
                 self.write_output(f, obj)
 
-            asset_name = "/".join(context.asset_key.path)
+            asset_name = PosixPath(*context.asset_key.path)
             commit = tx.commit(message=f"Add asset {asset_name}")
 
         context.add_output_metadata(

--- a/src/ames_housing/utils.py
+++ b/src/ames_housing/utils.py
@@ -1,12 +1,12 @@
 """Utilities."""
 
-import os
-from typing import List
+from typing import Union
 
-from ames_housing.constants import LAKEFS_BRANCH, LAKEFS_REPOSITORY
+from dagster import InputContext, OutputContext
 
 
-def get_key_prefix() -> List[str]:
-    if os.environ.get("ENV") == "production":
-        return [LAKEFS_REPOSITORY, LAKEFS_BRANCH]
-    return []
+def get_metadata(context: Union[OutputContext, InputContext]) -> dict:
+    if isinstance(context, OutputContext):
+        return context.metadata
+    else:  # type is InputContext
+        return context.upstream_output.metadata


### PR DESCRIPTION
We misused the asset key prefix for passing repository, branch, and (base) path information to the IO manager. Replacing it with the metadata field seems like a cleaner solution.